### PR TITLE
Add abi version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,20 @@ CC = gcc
 CFLAGS = -g -Wall -Werror -fPIC
 DEPS = resource.h res_impl.h resmem.h resnet.h resproc.h
 OBJ = resource.o resmem.o resnet.o resproc.o
-LIB = libresource.so
 TEST = test
 RM = rm -rf
 CP = cp
+ABI_MAJOR=0
+ABI_MINOR=1
+ABI_MICRO=1
+ABI=$(ABI_MAJOR).$(ABI_MINOR).$(ABI_MICRO)
+LIB = libresource.so.$(ABI)
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 all: $(OBJ)
-	$(CC) -shared -o $(LIB) $^ $(CFLAGS)
+	$(CC) -shared -Wl,-soname,libresource.so.$(ABI_MAJOR) -o $(LIB) $^ $(CFLAGS)
 
 .PHONY : clean
 clean:


### PR DESCRIPTION
Closes #8

1. add abi version with -soname link option
2. name the built library libresource.so.$(abi) (where of course
   abi is major.minor.releaseno)
3.  Call this 0.1.1.  Is there a different number we want to start at?

Tried to do this the simplest, least obtrusive way.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>