### PR TITLE
This change adds a new function res_read_kern() which is a call to fetch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -g -Wall -Werror -fPIC -std=gnu99
 DEPS = resource.h res_impl.h resmem.h resnet.h resproc.h
-OBJ = resource.o resmem.o resnet.o resproc.o
+OBJ = resource.o resmem.o resnet.o resproc.o reskern.o
 TEST = test
 RM = rm -rf
 CP = cp

--- a/README.md
+++ b/README.md
@@ -3,6 +3,26 @@ library of interfaces through which we can get system resource information
 like memory, CPU, stat, networking, device etc.
 Currently most of such information is read from /proc and /sys.
 
+## Compile
+To compile: 
+make all
+This will build libresource.so.0.1.1
+Set up symlinks:
+ln -s ./libresource.so.0.1.1 ./libresource.so
+ln -s ./libresource.so.0.1.1 ./libresource.so.0
+
+Compile a test program as follows:
+cc -I $LD_LIBRARY_PATH -std=gnu99 -o test  test.c -L $LD_LIBRARY_PATH -lresource
+
+where, $LD_LIBRARY_PATH is the location of your top level libresource code.
+
+To run, set LD_LIBRARY_PATH:
+export LD_LIBRARY_PATH=<libresource-directory>
+eg. LD_LIBRARY_PATH=/home/user/libresource
+
+Then run your test program:
+./test
+
 ## Use case:
 
 **1: Ease of use -**

--- a/reskern.c
+++ b/reskern.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022, Oracle and/or its affiliates. All rights reserved
+ *
+ * This file is part of libresource.
+ *
+ * libresource is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * libresource is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libresource. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/utsname.h>
+#include "resource.h"
+#include "resource_impl.h"
+
+char FILENAME[] = "/home/opc/pids";
+
+int get_pidarr(int **pidarr, int LEN) {
+        FILE *fp = NULL;
+        int i = 0;
+        int *tmparr;
+
+        fp = fopen(FILENAME, "r");
+        if (fp == NULL) {
+            printf("File %s not found\n",FILENAME);
+            return 1;
+        }
+        *pidarr = (int *) malloc(LEN*sizeof(int));
+        if (!*pidarr) {
+            printf("Out of memory, pidarr NULL\n");
+            return 1;
+        }
+        i = 0;
+        tmparr=*pidarr;
+        while ((fscanf(fp, "%d", *pidarr) == 1) && (i < LEN)) {
+            //printf("i: %d, pid %d\n",i, **pidarr);
+            (*pidarr)++;
+            i++;
+        }
+        *pidarr=tmparr;
+        if (i != LEN) {
+            printf("i & LEN mismatch, i %d, LEN %d\n", i, LEN);
+            LEN = i;
+        }
+        fclose(fp);
+        return 0;
+}
+
+int syscall_start_times(int *pidarr, unsigned long long *stimes, int LEN) {
+        		unsigned long long a;
+
+        a = syscall(474, RES_KERN_PID_START_TIME, LEN, pidarr, stimes);
+        if (a != 0) {
+            printf("Error, System call sys_get_vector returned %llu\n",a);
+            return 1;
+        } 
+        return 0;
+}
+
+void print_pid_start_times(int *pidarr, unsigned long long *stimes, int LEN) {
+	int i;
+	for (i = 0; i < LEN; i++) {
+    	    printf("[%d] start time of %d is %llu\n", i, pidarr[i], stimes[i]);
+	}
+}
+
+/* Read PID start time directly from kernel instead of /proc/$pid/stat
+ * This reads the start time from the task structure of the process
+ * directly from kernel, making it more efficient than going through /proc
+ * The field it reads is (from man page of /proc):
+ * (22) starttime  %llu
+                     The time the process started after system boot.  In
+                     kernels before Linux 2.6, this value was expressed
+                     in jiffies.  Since Linux 2.6, the value is
+                     expressed in clock ticks (divide by
+                     sysconf(_SC_CLK_TCK)).
+ * Input is a pointer to an array of integers containing the PIDs (int *pidarr)
+ * Output is a pointer to an array of unsigned long long (stimes)
+ * This should be allocated by the user as before calling res_read_kern as:
+ * stimes = (unsigned long long *)malloc(LEN*sizeof(unsigned long long));
+ * Appropriately, it should be freed by the caller after it's use
+ * len_sz is the length of in or out arrays (the no. of PIDs)
+ */
+int res_read_kern(int res_id, void *out, size_t len_sz, void *in)
+{
+	struct utsname t;
+        int ret;
+        int err;
+        char *rawdata;
+
+        switch (res_id) {
+        case RES_KERN_RELEASE:
+                ret = uname(&t);
+                if (ret == -1) {
+                        err = errno;
+                        printf("Error in reading kernel release");
+                        errno = err;
+                        return -1;
+                }
+                strncpy(out, t.release, len_sz-1);
+                ((char *)out)[len_sz-1] = '\0';
+                break;
+
+        case RES_KERN_COMPILE_TIME:
+                ret = uname(&t);
+                if (ret == -1) {
+                        err = errno;
+                        printf("Error in reading version (for compile time)");
+                        errno = err;
+                        return -1;
+                }
+                rawdata = skip_spaces(t.version, strlen(t.version), 3);
+                strncpy(out, rawdata, len_sz-1);
+                ((char *)out)[len_sz-1] = '\0';
+                break;
+
+        case RES_KERN_PID_START_TIME:
+		if (out == NULL) {
+			printf("out argument cannot be NULL");
+                        errno = EINVAL;
+                        return -1;
+		}
+		syscall_start_times((int *)in, (unsigned long long *)out, (int)len_sz);
+                break;
+
+        default:
+                printf("Resource Id is invalid");
+                errno = EINVAL;
+                return -1;
+        }
+	return 0;
+}
+

--- a/resource.c
+++ b/resource.c
@@ -164,11 +164,6 @@ void res_destroy_blk(res_blk_t *res)
  */
 int res_read(int res_id, void *out, size_t out_sz, void *hint, int pid, int flags)
 {
-	struct utsname t;
-	int ret;
-	int err;
-	char *rawdata;
-
 	if (out == NULL) {
 		switch (res_id) {
 		/* In case of RES_NET_ALLIFSTAT memory is allocated on the
@@ -196,37 +191,6 @@ int res_read(int res_id, void *out, size_t out_sz, void *hint, int pid, int flag
 	if (res_id >= NET_MIN && res_id < NET_MAX)
 		return getnetinfo(res_id, out, out_sz, hint, pid, flags);
 
-	switch (res_id) {
-	case RES_KERN_RELEASE:
-		ret = uname(&t);
-		if (ret == -1) {
-			err = errno;
-			eprintf("Error in reading kernel release");
-			errno = err;
-			return -1;
-		}
-		strncpy(out, t.release, out_sz-1);
-		((char *)out)[out_sz-1] = '\0';
-		break;
-
-	case RES_KERN_COMPILE_TIME:
-		ret = uname(&t);
-		if (ret == -1) {
-			err = errno;
-			eprintf("Error in reading version (for compile time)");
-			errno = err;
-			return -1;
-		}
-		rawdata = skip_spaces(t.version, strlen(t.version), 3);
-		strncpy(out, rawdata, out_sz-1);
-		((char *)out)[out_sz-1] = '\0';
-		break;
-
-	default:
-		eprintf("Resource Id is invalid");
-		errno = EINVAL;
-		return -1;
-	}
 	return 0;
 }
 


### PR DESCRIPTION
This change adds a new function res_read_kern() which is a call to fetch a vectored list of "start times" of processes whose PIDs are given in an array, directly from kernel instead of going through /proc, to improve performance. See the note on top of this function in resource.h for more documentation. If the new system call is not present in the kernel, it just returns an error.