### PR TITLE
Skip RTN_BROADCAST & RTN_MULTICAST routes in net_route.c

### DIFF
--- a/net_route.c
+++ b/net_route.c
@@ -348,6 +348,10 @@ static int handle_route_resp(int net_sock, void **out)
 #endif
 			parse_attr(at, RTM_RTA(rt), len);
 			if (rt->rtm_family == AF_INET || rt->rtm_family == AF_INET6) {
+				if ((rt->rtm_type == RTN_BROADCAST) ||
+				    (rt->rtm_type == RTN_MULTICAST))
+					continue;
+
 				get_attr(at, iroutes, rt);
 #ifdef TESTING
 				fp = fopen ("./route_info.txt", "w");

--- a/rescpu.c
+++ b/rescpu.c
@@ -221,6 +221,12 @@ next:
 			else
 				cpu->bogomips = atof(end2);
 		}
+		if (!strcmp(start, "TLB size")) {
+			if (probe)
+				cpu->tlb_size[0] = 1;
+			else
+				strcpy(cpu->tlb_size, end2);
+		}
 		if (!strcmp(start, "clflush size")) {
 			if (probe)
 				cpu->clflush_size = 1;
@@ -245,7 +251,6 @@ next:
 			else
 				strcpy(cpu->power_mgmt, end2);
 		}
-
 nextline:
 		start = start2;
 		start++;

--- a/resmem.c
+++ b/resmem.c
@@ -353,12 +353,9 @@ int getmemexist(int res_id, void *exist, size_t sz, void *hint, int flags)
 int getmeminfo(int res_id, void *out, size_t sz, void **hint, int pid, int flags)
 {
 	char buf[4096];
-	//FILE *fp;
-	//int err = 0;
 	size_t active_anon, active_file, inactive_anon, inactive_file, cache,
 		swaptotal, swapfree, swtot, swusage, mmusage, mmtot, memtotal;
 	int ret = 0;
-	//res_mem_infoall_t *mminfo;
 
 	char *cg = get_cgroup(pid, MEMCGNAME);
 

--- a/resource.h
+++ b/resource.h
@@ -207,6 +207,7 @@ struct cpuinfo {
 	unsigned int cache_alignment;
 	char address_sizes[CPU_STR];
 	char power_mgmt[CPU_STR];
+	char tlb_size[CPU_STR];
 };
 
 struct memstat {

--- a/tests/CPU/cpu_test.c
+++ b/tests/CPU/cpu_test.c
@@ -106,6 +106,8 @@ int main(int argc, char **argv)
 			fprintf(fp, "bugs\t\t: %s\n",cpu->bugs);
 		if (exist->bogomips)
 			fprintf(fp, "bogomips\t: %0.2f\n",cpu->bogomips);
+		if (exist->tlb_size[0])
+			fprintf(fp, "TLB size\t: %s\n",cpu->tlb_size);
 		if (exist->clflush_size)
 			fprintf(fp, "clflush size\t: %u\n",cpu->clflush_size);
 		if (exist->cache_alignment)


### PR DESCRIPTION
The kernel code for parsing /proc/net/route (fib_route_seq_show()) skips RTN_BROADCAST & RTN_MULTICAST - do the same in net_route.c.