### PR TITLE
mem.sh fix

### DIFF
--- a/tests/MEM/Makefile
+++ b/tests/MEM/Makefile
@@ -1,14 +1,14 @@
 CC = gcc
 export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
-CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH) -lresource 
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
 REXE = mem_test mem_test_cg
 MFILES = mem_info.*
 
 mem_test: mem_test.c 
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
 
 mem_test_cg: mem_test_cg.c 
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
 
 clean:
 	rm -rf $(MFILES) $(REXE)

--- a/tests/MEM/mem.sh
+++ b/tests/MEM/mem.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 
 # Enable -DTESTING in Makefile and the recompile library - make
-make clean
 
+export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
+cd $LD_LIBRARY_PATH/tests/MEM
+
+make clean
 make mem_test
+
 cat /proc/meminfo > mem_info.orig
 sed -i 's/[ ]\+/ /g' mem_info.orig
 ./mem_test


### PR DESCRIPTION
On the Ubuntu system on which qa_test.yml is run, gcc does not seem to accept -lresource as a CFLAGS. Instead, added this on the 'make' target.