### PR TITLE
Makefile for tests/ARP

### DIFF
--- a/tests/ARP/Makefile
+++ b/tests/ARP/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = arp_test
+MFILES = arp_info.*
+
+arp_test: arp_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/ARP/arp.sh
+++ b/tests/ARP/arp.sh
@@ -1,11 +1,10 @@
 # Enable -DTESTING in Makefile and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/ARP
-rm -f ./arp_test
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o arp_test arp_test.c -L $LD_LIBRARY_PATH -lresource
-rm -f ./arp_info.orig
-rm -f ./arp_info.txt
+cd $LD_LIBRARY_PATH/tests/ARP
+
+make clean
+make arp_test
+
 arp -n -a > arp_info.orig
 #remove all "? " from above file
 sed -i 's/? //g' arp_info.orig 

--- a/tests/CPU/Makefile
+++ b/tests/CPU/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = cpu_test
+MFILES = cpu_info.*
+
+cpu_test: cpu_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/CPU/cpu.sh
+++ b/tests/CPU/cpu.sh
@@ -1,11 +1,10 @@
 # Enable #define TESTING and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/CPU
-rm -f cpu_test
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o cpu_test cpu_test.c -L $LD_LIBRARY_PATH -lresource
-rm -f ./cpu_info.orig
-rm -f ./cpu_info.txt
+cd $LD_LIBRARY_PATH/tests/CPU
+
+make clean
+make cpu_test
+
 cat /proc/cpuinfo > ./cpu_info.orig
 ./cpu_test
 diff ./cpu_info.orig ./cpu_info.txt

--- a/tests/FS/Makefile
+++ b/tests/FS/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = fs_test
+MFILES = fs_info.*
+
+fs_test: fs_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/FS/fs.sh
+++ b/tests/FS/fs.sh
@@ -1,7 +1,8 @@
 # Enable #define TESTING and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/FS
-rm -f fs_test
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o fs_test fs_test.c -L $LD_LIBRARY_PATH -lresource
+cd $LD_LIBRARY_PATH/tests/FS
+
+make clean
+make fs_test
+
 ./fs_test

--- a/tests/IF/Makefile
+++ b/tests/IF/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = if_test
+MFILES = if_info.*
+
+if_test: if_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/IF/if.sh
+++ b/tests/IF/if.sh
@@ -1,8 +1,8 @@
 # Enable -DTESTING in Makefile and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/IF
-rm -f ./if_test
-rm -f ./if_info.txt
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o if_test if_test.c -L $LD_LIBRARY_PATH -lresource
+cd $LD_LIBRARY_PATH/tests/IF
+
+make clean
+make if_test
+
 ./if_test

--- a/tests/MISC/Makefile
+++ b/tests/MISC/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = tests
+MFILES = vm_info.orig
+
+tests: tests.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/MISC/tests.sh
+++ b/tests/MISC/tests.sh
@@ -1,9 +1,9 @@
 # Enable -DTESTING in Makefile and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/MISC
-rm -f tests
-rm -f ./vm_info.orig
+cd $LD_LIBRARY_PATH/tests/MISC
+
+make clean
+make tests
+
 cat /proc/vmstat > ./vm_info.orig
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o tests tests.c -L $LD_LIBRARY_PATH -lresource
 ./tests

--- a/tests/ROUTE/Makefile
+++ b/tests/ROUTE/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = route_test
+MFILES = route_info.*
+
+route_test: route_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/ROUTE/route.sh
+++ b/tests/ROUTE/route.sh
@@ -1,11 +1,10 @@
 # Enable -DTESTING in Makefile and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/ROUTE
-rm -f ./route_test
-rm -f ./route_info.orig
-rm -f ./route_info.txt
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o route_test route_test.c -L $LD_LIBRARY_PATH -lresource
+cd $LD_LIBRARY_PATH/tests/ROUTE
+
+make clean
+make route_test
+
 ip route > ./route_info.orig
 # Temporary fix to remove "linkdown" from route output, because we do not
 # handle it in net_route.c yet. This will allow route.sh to succeed.

--- a/tests/STAT/Makefile
+++ b/tests/STAT/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = stat_test
+MFILES = stat_info.*
+
+stat_test: stat_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/STAT/stat.sh
+++ b/tests/STAT/stat.sh
@@ -1,9 +1,9 @@
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/STAT
-rm -f stat_info.orig
-rm -f stat_info.txt
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o stat_test stat_test.c -L $LD_LIBRARY_PATH -lresource
+cd $LD_LIBRARY_PATH/tests/STAT
+
+make clean
+make stat_test
+
 cat /proc/stat > stat_info.orig
 ./stat_test
 diff stat_info.orig stat_info.txt

--- a/tests/VM/Makefile
+++ b/tests/VM/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+export LD_LIBRARY_PATH = `git rev-parse --show-toplevel`
+CFLAGS = -g -Wall -Werror -I $(LD_LIBRARY_PATH) -std=gnu99 -L $(LD_LIBRARY_PATH)
+REXE = vm_test
+MFILES = vm_info.*
+
+vm_test: vm_test.c 
+	$(CC) $(CFLAGS) -o $@ $^ -lresource
+
+clean:
+	rm -rf $(MFILES) $(REXE)

--- a/tests/VM/vm.sh
+++ b/tests/VM/vm.sh
@@ -2,12 +2,11 @@
 
 # Enable -DTESTING in Makefile and the recompile library - make
 export LD_LIBRARY_PATH=`git rev-parse --show-toplevel`
-cd $LD_LIBRARY_PATH
-cd tests/VM
-rm -f vm_test
-cc -I $LD_LIBRARY_PATH -std=gnu99 -o vm_test vm_test.c -L $LD_LIBRARY_PATH -lresource
-rm -f ./vm_info.orig
-rm -f ./vm_info.txt
+cd $LD_LIBRARY_PATH/tests/VM
+
+make clean
+make vm_test
+
 cat /proc/vmstat > ./vm_info.orig
 ./vm_test
 diff ./vm_info.orig ./vm_info.txt

--- a/tests/VM/vm_test.c
+++ b/tests/VM/vm_test.c
@@ -25,7 +25,6 @@
 int main(int argc, char **argv)
 {
         struct vmstat data, exist;
-	unsigned long value;
 	FILE *fp;
 	int ret;
 


### PR DESCRIPTION
Add new Makefile in tests/ARP, and modify arp.sh accordingly. Added Makefile infrastructure for all tests:
CPU, FS, IF, MEM, MISC, ROUTE, STAT, VM.
Modified their *.sh files accordingly.